### PR TITLE
Original video is sent to the compressor (iOS's default compression r…

### DIFF
--- a/lightcompressorsample/ViewController.swift
+++ b/lightcompressorsample/ViewController.swift
@@ -124,6 +124,7 @@ class ViewController: UIViewController, UIImagePickerControllerDelegate, UINavig
             self.imagePickerController?.sourceType = .photoLibrary
             self.imagePickerController?.mediaTypes = ["public.movie"]
             self.imagePickerController?.videoQuality = UIImagePickerController.QualityType.typeHigh
+            self.imagePickerController?.videoExportPreset = AVAssetExportPresetPassthrough
             self.present(self.imagePickerController!, animated: true, completion: nil)
         }
     }


### PR DESCRIPTION
Before, while picking up the video iOS compressed the video first then that compressed video is used as an input to the implemented compressor (Custom compressor).

That's why removed the default compression and sent the original video as an input to the custom compressor.
